### PR TITLE
Separate extensions and fix safari button

### DIFF
--- a/safari-extension/popup.js
+++ b/safari-extension/popup.js
@@ -10,17 +10,35 @@ document.addEventListener('DOMContentLoaded', function() {
   const resetSessionBtn = document.getElementById('reset-session');
   const sessionTime = document.getElementById('session-time');
 
-  // Safari-compatible storage functions using extension storage API
+  // Safari-compatible storage functions using message passing to background script
   function getStorageData() {
     return new Promise((resolve) => {
       try {
-        chrome.storage.local.get(['youtubeShortsTracker'], function(result) {
-          const data = result.youtubeShortsTracker || {
-            shortsVisited: [],
-            shortsLimit: 10,
-            sessionStartTime: Date.now()
-          };
-          resolve(data);
+        chrome.runtime.sendMessage({ action: 'getStats' }, function(response) {
+          if (chrome.runtime.lastError) {
+            console.error('Chrome runtime error:', chrome.runtime.lastError);
+            resolve({
+              shortsVisited: [],
+              shortsLimit: 10,
+              sessionStartTime: Date.now()
+            });
+          } else if (response) {
+            resolve({
+              shortsVisited: response.shortsVisited || [],
+              shortsLimit: response.shortsLimit || 10,
+              sessionStartTime: response.sessionStartTime || Date.now()
+            });
+          } else {
+            // Fallback to direct storage access if message passing fails
+            chrome.storage.local.get(['youtubeShortsTracker'], function(result) {
+              const data = result.youtubeShortsTracker || {
+                shortsVisited: [],
+                shortsLimit: 10,
+                sessionStartTime: Date.now()
+              };
+              resolve(data);
+            });
+          }
         });
       } catch (error) {
         console.error('Error reading storage:', error);
@@ -33,14 +51,37 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
-  function setStorageData(data) {
+  function updateLimit(newLimit) {
     return new Promise((resolve) => {
       try {
-        chrome.storage.local.set({ youtubeShortsTracker: data }, function() {
-          resolve(true);
+        chrome.runtime.sendMessage({ action: 'updateLimit', limit: newLimit }, function(response) {
+          if (chrome.runtime.lastError) {
+            console.error('Chrome runtime error:', chrome.runtime.lastError);
+            resolve(false);
+          } else {
+            resolve(response && response.success);
+          }
         });
       } catch (error) {
-        console.error('Error writing storage:', error);
+        console.error('Error updating limit:', error);
+        resolve(false);
+      }
+    });
+  }
+
+  function resetSession() {
+    return new Promise((resolve) => {
+      try {
+        chrome.runtime.sendMessage({ action: 'resetSession' }, function(response) {
+          if (chrome.runtime.lastError) {
+            console.error('Chrome runtime error:', chrome.runtime.lastError);
+            resolve(false);
+          } else {
+            resolve(response && response.success);
+          }
+        });
+      } catch (error) {
+        console.error('Error resetting session:', error);
         resolve(false);
       }
     });
@@ -100,11 +141,13 @@ document.addEventListener('DOMContentLoaded', function() {
   updateLimitBtn.addEventListener('click', async function() {
     const newLimit = parseInt(limitInput.value);
     if (newLimit > 0 && newLimit <= 100) {
-      const data = await getStorageData();
-      data.shortsLimit = newLimit;
-      await setStorageData(data);
-      loadStats(); // Reload stats to reflect new limit
-      showNotification('Limit updated successfully!');
+      const success = await updateLimit(newLimit);
+      if (success) {
+        loadStats(); // Reload stats to reflect new limit
+        showNotification('Limit updated successfully!');
+      } else {
+        showNotification('Failed to update limit. Please try again.', 'error');
+      }
     } else {
       showNotification('Please enter a valid limit (1-100)', 'error');
     }
@@ -113,12 +156,13 @@ document.addEventListener('DOMContentLoaded', function() {
   // Reset session
   resetSessionBtn.addEventListener('click', async function() {
     if (confirm('Are you sure you want to reset the current session? This will clear all tracked shorts.')) {
-      const data = await getStorageData();
-      data.shortsVisited = [];
-      data.sessionStartTime = Date.now();
-      await setStorageData(data);
-      loadStats(); // Reload stats
-      showNotification('Session reset successfully!');
+      const success = await resetSession();
+      if (success) {
+        loadStats(); // Reload stats
+        showNotification('Session reset successfully!');
+      } else {
+        showNotification('Failed to reset session. Please try again.', 'error');
+      }
     }
   });
 


### PR DESCRIPTION
Separate Safari and Chrome extensions and fix the Safari extension's reset session button.

The reset session button in the Safari extension was not working due to direct `chrome.storage.local` access in `popup.js`. This PR updates `popup.js` to use message passing to the background script for storage operations, which is more reliable for Safari extensions. The `unified-extension` folder was also deleted as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-beaffb51-f683-460d-bf27-48f9115ae485">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-beaffb51-f683-460d-bf27-48f9115ae485">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

